### PR TITLE
Engine work

### DIFF
--- a/mbam/engine.py
+++ b/mbam/engine.py
@@ -30,6 +30,7 @@ class Engine:
         self.curr_model = self.model
         self.curr_id = self.model_id
 
+    
     def run(self, printing=False):
         """Runs the geodesic, infers the limit, attempts to evaluate the limit.
         Continues to repeat the process until a failure.
@@ -41,6 +42,7 @@ class Engine:
         """
         for i in range(len(self.curr_model.model_ps)):
             self.curr_iter = Iteration(self.curr_model, self.curr_id, self.data_path)
+            self.curr_iter.write_model_script(self.curr_iter.julia.options)  # create model.jl file
             if self.curr_iter.auto_run():
                 print("PASS!")
                 self.curr_model = self.curr_iter.N_minus_1

--- a/mbam/parsing/base.py
+++ b/mbam/parsing/base.py
@@ -3,6 +3,7 @@ from sympy.printing import julia_code
 from sympy import Symbol
 import json
 import logging
+import re
 
 class BaseParser:
     """Parent class for all model parsers.
@@ -270,3 +271,10 @@ class BaseParser:
             kwargs += "]"
         self.logger.debug("Parsed kwargs = %s" %kwargs)
         return kwargs
+
+    def find_replace_vectorized(self,string):
+        d = {"\.\*": ' .* ', "\.\/": ' ./ ', "\.\^": ' .^ '}
+        for item in d.keys():
+            # sub item for item's paired value in string
+            string = re.sub(item, d[item], string)
+        return string

--- a/mbam/parsing/ode.py
+++ b/mbam/parsing/ode.py
@@ -41,6 +41,7 @@ class ODEParser(BaseDiffParser):
             self.script += self.write_bare_model()
         self.script += 'xi = ParametricModels.xvalues(parametricmodel)\n'
         self.script += 'end # module'
+        self.script = self.find_replace_vectorized(self.script)
 
     def write_bare_model(self):
         ret = ''


### PR DESCRIPTION
* added Julia 1.0 dot syntax for vectorizing functions {.*, ./, .^} - mbam.parsing.base.BaseParser.find_replace_vectorized()
* changed function signature of mbam.parsing.dae.DAEParser.write_res()
* changed mbam.parsing.dae.DAEParser.write_ic_subs() such that initial conditions for variables in auxiliary functions (e.g. in the MM_4 model example: x_1_inact = -_x[1] + ps.x_1_total -> x_1_inact = -ps.x_1_init + ps.x_1_total) are also substituted
* added Julia script generation to mbam.engine.Engine.run()